### PR TITLE
add chain ID 3335 for ethstorage mainnet

### DIFF
--- a/_data/chains/eip155-3335.json
+++ b/_data/chains/eip155-3335.json
@@ -1,0 +1,16 @@
+{
+  "name": "EthStorage Devnet",
+  "chain": "EthStorage",
+  "rpc": ["http://devnet.ethstorage.io:9540"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://ethstorage.io/",
+  "shortName": "es-d",
+  "chainId": 3335,
+  "networkId": 3335,
+  "slip44": 1
+}

--- a/_data/chains/eip155-3335.json
+++ b/_data/chains/eip155-3335.json
@@ -1,7 +1,7 @@
 {
-  "name": "EthStorage Devnet",
+  "name": "EthStorage Mainnet",
   "chain": "EthStorage",
-  "rpc": ["http://devnet.ethstorage.io:9540"],
+  "rpc": ["http://mainnet.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://ethstorage.io/",
-  "shortName": "es-d",
+  "shortName": "es-m",
   "chainId": 3335,
   "networkId": 3335,
   "slip44": 1


### PR DESCRIPTION
Just reserve chain ID 3335 for EthStorage mainnet. We are still working on its RPC (http://mainnet.ethstorage.io:9540), and we will update its value ​​later if needed.