### PR TITLE
Resolve chain IDs for ethstorage chains and ethstorage l2 chains

### DIFF
--- a/_data/chains/eip155-3332.json
+++ b/_data/chains/eip155-3332.json
@@ -1,7 +1,7 @@
 {
-  "name": "EthStorage L2 Devnet",
+  "name": "EthStorage L2 Mainnet",
   "chain": "EthStorage",
-  "rpc": ["http://devnet.l2.ethstorage.io:9540"],
+  "rpc": ["http://mainnet.l2.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,8 +9,8 @@
     "decimals": 18
   },
   "infoURL": "https://ethstorage.io/",
-  "shortName": "esl2-d",
-  "chainId": 3335,
-  "networkId": 3335,
+  "shortName": "esl2-m",
+  "chainId": 3332,
+  "networkId": 3332,
   "slip44": 1
 }

--- a/_data/chains/eip155-3336.json
+++ b/_data/chains/eip155-3336.json
@@ -1,7 +1,7 @@
 {
-  "name": "EthStorage L2 Devnet",
+  "name": "EthStorage L2 Testnet",
   "chain": "EthStorage",
-  "rpc": ["http://devnet.l2.ethstorage.io:9540"],
+  "rpc": ["http://testnet.l2.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,8 +9,8 @@
     "decimals": 18
   },
   "infoURL": "https://ethstorage.io/",
-  "shortName": "esl2-d",
-  "chainId": 3335,
-  "networkId": 3335,
+  "shortName": "esl2-t",
+  "chainId": 3336,
+  "networkId": 3336,
   "slip44": 1
 }

--- a/_data/chains/eip155-3337.json
+++ b/_data/chains/eip155-3337.json
@@ -1,7 +1,7 @@
 {
-  "name": "EthStorage L2 Devnet",
+  "name": "EthStorage Devnet",
   "chain": "EthStorage",
-  "rpc": ["http://devnet.l2.ethstorage.io:9540"],
+  "rpc": ["http://devnet.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,8 +9,8 @@
     "decimals": 18
   },
   "infoURL": "https://ethstorage.io/",
-  "shortName": "esl2-d",
-  "chainId": 3335,
-  "networkId": 3335,
+  "shortName": "es-d",
+  "chainId": 3337,
+  "networkId": 3337,
   "slip44": 1
 }

--- a/_data/chains/eip155-3339.json
+++ b/_data/chains/eip155-3339.json
@@ -1,7 +1,7 @@
 {
-  "name": "EthStorage L2 Devnet",
+  "name": "EthStorage Mainnet",
   "chain": "EthStorage",
-  "rpc": ["http://devnet.l2.ethstorage.io:9540"],
+  "rpc": ["http://mainnet.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,8 +9,8 @@
     "decimals": 18
   },
   "infoURL": "https://ethstorage.io/",
-  "shortName": "esl2-d",
-  "chainId": 3335,
-  "networkId": 3335,
+  "shortName": "es-m",
+  "chainId": 3339,
+  "networkId": 3339,
   "slip44": 1
 }


### PR DESCRIPTION
Resolve chain IDs for ethstorage chains and ethstorage l2 chains:
- 3332: EthStorage L2 Mainnet
- 3333: EthStorage Testnet
- 3335: EthStorage L2 Devnet
- 3336: EthStorage L2 Testnet
- 3337: EthStorage Devnet
- 3339: EthStorage Mainnet