### PR TITLE
Reuse chainID 333 for EthStorage networks and update EthStorage L2/Testnet/Devnet chain IDs

### DIFF
--- a/_data/chains/eip155-333.json
+++ b/_data/chains/eip155-333.json
@@ -1,22 +1,21 @@
 {
-  "name": "Web3Q Mainnet",
-  "chain": "Web3Q",
-  "rpc": ["https://mainnet.web3q.io:8545"],
+  "name": "EthStorage Mainnet",
+  "chain": "EthStorage",
+  "rpc": ["http://mainnet.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Web3Q",
-    "symbol": "W3Q",
+    "name": "Ether",
+    "symbol": "ETH",
     "decimals": 18
   },
-  "infoURL": "https://web3q.io/home.w3q/",
-  "shortName": "w3q",
+  "infoURL": "https://ethstorage.io/",
+  "shortName": "es-m",
   "chainId": 333,
   "networkId": 333,
-  "explorers": [
-    {
-      "name": "w3q-mainnet",
-      "url": "https://explorer.mainnet.web3q.io",
-      "standard": "EIP3091"
-    }
-  ]
+  "slip44": 1,
+  "status": "incubating",
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1"
+  }
 }

--- a/_data/chains/eip155-333.json
+++ b/_data/chains/eip155-333.json
@@ -1,7 +1,7 @@
 {
   "name": "EthStorage Mainnet",
   "chain": "EthStorage",
-  "rpc": ["http://mainnet.ethstorage.io:9540"],
+  "rpc": ["https://rpc.mainnet.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-3332.json
+++ b/_data/chains/eip155-3332.json
@@ -1,6 +1,6 @@
 {
   "name": "EthStorage L2 Mainnet",
-  "chain": "EthStorage",
+  "chain": "EthStorage L2",
   "rpc": ["http://mainnet.l2.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
@@ -16,6 +16,6 @@
   "status": "incubating",
   "parent": {
     "type": "L2",
-    "chain": "eip155-1"
+    "chain": "eip155-100011"
   }
 }

--- a/_data/chains/eip155-3332.json
+++ b/_data/chains/eip155-3332.json
@@ -1,7 +1,7 @@
 {
   "name": "EthStorage L2 Mainnet",
   "chain": "EthStorage L2",
-  "rpc": ["http://mainnet.l2.ethstorage.io:9540"],
+  "rpc": ["https://rpc.mainnet.l2.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-3333.json
+++ b/_data/chains/eip155-3333.json
@@ -1,7 +1,7 @@
 {
   "name": "EthStorage Testnet",
   "chain": "EthStorage",
-  "rpc": ["http://testnet.ethstorage.io:9540"],
+  "rpc": ["https://rpc.testnet.ethstorage.io:9546"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -12,5 +12,9 @@
   "shortName": "es-t",
   "chainId": 3333,
   "networkId": 3333,
-  "slip44": 1
+  "slip44": 1,
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111"
+  }
 }

--- a/_data/chains/eip155-3336.json
+++ b/_data/chains/eip155-3336.json
@@ -1,6 +1,6 @@
 {
   "name": "EthStorage L2 Testnet",
-  "chain": "EthStorage",
+  "chain": "EthStorage L2",
   "rpc": ["http://testnet.l2.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-3336.json
+++ b/_data/chains/eip155-3336.json
@@ -1,7 +1,7 @@
 {
   "name": "EthStorage L2 Testnet",
   "chain": "EthStorage L2",
-  "rpc": ["http://testnet.l2.ethstorage.io:9540"],
+  "rpc": ["https://rpc.testnet.l2.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-3336.json
+++ b/_data/chains/eip155-3336.json
@@ -16,6 +16,6 @@
   "status": "incubating",
   "parent": {
     "type": "L2",
-    "chain": "eip155-11155111"
+    "chain": "eip155-110011"
   }
 }

--- a/_data/chains/eip155-3337.json
+++ b/_data/chains/eip155-3337.json
@@ -1,7 +1,7 @@
 {
   "name": "EthStorage Devnet",
   "chain": "EthStorage",
-  "rpc": ["http://devnet.ethstorage.io:9540"],
+  "rpc": ["https://rpc.devnet.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-3339.json
+++ b/_data/chains/eip155-3339.json
@@ -1,7 +1,7 @@
 {
-  "name": "EthStorage Mainnet",
-  "chain": "EthStorage",
-  "rpc": ["http://mainnet.ethstorage.io:9540"],
+  "name": "EthStorage L2 Devnet",
+  "chain": "EthStorage L2",
+  "rpc": ["http://devnet.l2.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://ethstorage.io/",
-  "shortName": "es-m",
+  "shortName": "esl2-d",
   "chainId": 3339,
   "networkId": 3339,
   "slip44": 1,

--- a/_data/chains/eip155-3339.json
+++ b/_data/chains/eip155-3339.json
@@ -1,7 +1,7 @@
 {
   "name": "EthStorage L2 Devnet",
   "chain": "EthStorage L2",
-  "rpc": ["http://devnet.l2.ethstorage.io:9540"],
+  "rpc": ["https://rpc.devnet.l2.ethstorage.io:9540"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",


### PR DESCRIPTION
The Web3Q Mainnet is currently deprecated. We want to reuse the chainID 333 and make some adjustments to the EthStorage related Chain IDs:

333: EthStorage Mainnet  
3332: EthStorage L2 Mainnet

3333: EthStorage Testnet
3336: EthStorage L2 Testnet

3337: EthStorage Devnet
3339: EthStorage L2 Devnet